### PR TITLE
Update environment variables specified in godel/config/godel.yml

### DIFF
--- a/dirs/godel/config/godel.yml
+++ b/dirs/godel/config/godel.yml
@@ -7,9 +7,6 @@ plugins:
         checksums:
           darwin-amd64: 08a65d8db9555c4580dbf6cdfd954ffafc687ecbf5a71a643bc190baa9b774ad
           linux-amd64: dda61df35df69154836b4f6caa14f88d6b1a59acdb99005e5f5de986fa33f37b
-environment:
-  GO111MODULE: "on"
-  GOFLAGS: "-mod=vendor"
 exclude:
   names:
     - "\\..+"

--- a/errorstringer/godel/config/godel.yml
+++ b/errorstringer/godel/config/godel.yml
@@ -7,9 +7,6 @@ plugins:
         checksums:
           darwin-amd64: 08a65d8db9555c4580dbf6cdfd954ffafc687ecbf5a71a643bc190baa9b774ad
           linux-amd64: dda61df35df69154836b4f6caa14f88d6b1a59acdb99005e5f5de986fa33f37b
-environment:
-  GO111MODULE: "on"
-  GOFLAGS: "-mod=vendor"
 exclude:
   names:
     - "\\..+"

--- a/gofiles/godel/config/godel.yml
+++ b/gofiles/godel/config/godel.yml
@@ -7,9 +7,6 @@ plugins:
         checksums:
           darwin-amd64: 08a65d8db9555c4580dbf6cdfd954ffafc687ecbf5a71a643bc190baa9b774ad
           linux-amd64: dda61df35df69154836b4f6caa14f88d6b1a59acdb99005e5f5de986fa33f37b
-environment:
-  GO111MODULE: "on"
-  GOFLAGS: "-mod=vendor"
 exclude:
   names:
     - "\\..+"


### PR DESCRIPTION
No longer necessary to set -mod=vendor flag or GO111MODULE mode
given versions of Go used to build the modules.