### PR TITLE
dirs: update godel to v2.67.0 and go-mod-plugin to v1.20.0

### DIFF
--- a/dirs/godel/config/godel.properties
+++ b/dirs/godel/config/godel.properties
@@ -1,2 +1,2 @@
-distributionURL=https://github.com/palantir/godel/releases/download/v2.39.0/godel-2.39.0.tgz
-distributionSHA256=6db200926037532f2f22322c84be8c34808e5acf89cad6200c9d7a9857fc0fa2
+distributionURL=https://github.com/palantir/godel/releases/download/v2.67.0/godel-2.67.0.tgz
+distributionSHA256=

--- a/dirs/godel/config/godel.yml
+++ b/dirs/godel/config/godel.yml
@@ -5,8 +5,8 @@ plugins:
     - locator:
         id: com.palantir.godel-mod-plugin:mod-plugin:1.20.0
         checksums:
-          darwin-amd64: 08a65d8db9555c4580dbf6cdfd954ffafc687ecbf5a71a643bc190baa9b774ad
-          linux-amd64: dda61df35df69154836b4f6caa14f88d6b1a59acdb99005e5f5de986fa33f37b
+          darwin-amd64: 96f9232e67e280f28df05e829e77ecba10ad81904d4bc928cdbd94ee2ed15807
+          linux-amd64: f03cec464d0238c07e3bc647881e6190f930ce777f33aba03a94b6b17e190afe
 environment:
   GO111MODULE: "on"
   GOFLAGS: "-mod=vendor"

--- a/dirs/godel/config/godel.yml
+++ b/dirs/godel/config/godel.yml
@@ -3,7 +3,7 @@ plugins:
     - https://github.com/{{index GroupParts 1}}/{{index GroupParts 2}}/releases/download/v{{Version}}/{{Product}}-{{Version}}-{{OS}}-{{Arch}}.tgz
   plugins:
     - locator:
-        id: com.palantir.godel-mod-plugin:mod-plugin:1.3.0
+        id: com.palantir.godel-mod-plugin:mod-plugin:1.20.0
         checksums:
           darwin-amd64: 08a65d8db9555c4580dbf6cdfd954ffafc687ecbf5a71a643bc190baa9b774ad
           linux-amd64: dda61df35df69154836b4f6caa14f88d6b1a59acdb99005e5f5de986fa33f37b

--- a/dirs/godelw
+++ b/dirs/godelw
@@ -3,11 +3,11 @@
 set -euo pipefail
 
 # Version and checksums for godel. Values are populated by the godel "dist" task.
-VERSION=2.39.0
-DARWIN_AMD64_CHECKSUM=2e8bb7d29d044352ba61d1216e4d06fff2390b79c533928923870711f8ae6f42
-DARWIN_ARM64_CHECKSUM=ee342e29a8520d4d676184cbaecd6a9d2989422b0b268d7e033071cff86f78ab
-LINUX_AMD64_CHECKSUM=9bbc5cff2516d75244503f264e1c8b18349e29886ed33f6e8177afc587a1baf0
-LINUX_ARM64_CHECKSUM=9c5191d26c2cb690c76576caa23e72e303e6c5bcc006684b7d17d3246d8fc1f2
+VERSION=2.67.0
+DARWIN_AMD64_CHECKSUM=323edc3ba73150e46e59a90146e086e5587b1d402f3288dd79e43ff856907e37
+DARWIN_ARM64_CHECKSUM=528db442c313060abdacf2bb496d4adb49dcf492924e8b62c0f699f25aeed358
+LINUX_AMD64_CHECKSUM=b58be2904fd04e2238af0ddfa1021000e2b0e9f9d530c04b3ea66e3f0fcc47b5
+LINUX_ARM64_CHECKSUM=dd96d9a622dc28054cd6d3f83322ecf53a02ff481500b0d0f6d3a757685df13f
 
 # Downloads file at URL to destination path using wget or curl. Prints an error and exits if wget or curl is not present.
 function download {
@@ -91,7 +91,7 @@ function compute_sha256 {
     local file=$1
     if command -v openssl >/dev/null 2>&1; then
         # print SHA-256 hash using openssl
-        openssl dgst -sha256 "$file" | sed -E 's/SHA256\(.*\)= //'
+        openssl dgst -sha256 "$file" | sed -E 's/SHA(2-)?256\(.*\)= //'
     elif command -v shasum >/dev/null 2>&1; then
         # Darwin systems ship with "shasum" utility
         shasum -a 256 "$file" | sed -E 's/[[:space:]]+.+//'


### PR DESCRIPTION
Pre-commit to updating the go.mod version to 1.19 since godel v2.67.0 includes the upgrade to Go1.19. 

Additionally, Go 1.17 introduces module graph pruning which will help to not pull in transitive dependencies for upstream consumers so we want to get to that version asap.